### PR TITLE
docs: PR 템플릿에서 [플랫폼] prefix 제거

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
 <!--
-PR 제목 컨벤션: [플랫폼] 타입: 50자 이내 제목
-예) [BE] feat: OAuth 로그인 API 구현
+PR 제목 컨벤션: 타입: 50자 이내 제목 (scope optional)
+예) feat: OAuth 로그인 API 구현
+    refactor(policies): service 피처에서 policies 피처로 분리
 -->
 
 ## 📝 변경 사항


### PR DESCRIPTION
조직 컨벤션 변경: 커밋/PR 메시지에서 `[플랫폼]` prefix 제거.

각 레포가 플랫폼별로 분리되어 있어 prefix가 중복 정보입니다.
이슈 템플릿의 🎯 Platform dropdown은 유지 (Project 보드 / 라벨 자동화에 사용).

## 📝 변경 사항
- `.github/pull_request_template.md` PR 제목 컨벤션 안내 갱신

## 🔗 source
https://github.com/jiu-jitsu-org/project-management/blob/main/WORKFLOW.md